### PR TITLE
returning empty client if client not found.

### DIFF
--- a/services/client-management-service.js
+++ b/services/client-management-service.js
@@ -71,6 +71,7 @@ exports.getClient = function(clientUuid, roleUuid) {
       // Now get the results of the async queries and collect all results into the result DTO
       findClientQueryPromise.then(
         client => {
+          if (client === null) resolve(clientDTO);
           _fillDtoWithClientDetails(clientDTO, client);
           return findAllAddressesForClientQueryPromise;
         }


### PR DESCRIPTION
This is required in case of new user registration when the user still does not have any devices, addresses, emails, contacts, etc., assigned to him/her.